### PR TITLE
Add CSVTableV0 node and Dynamic nodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "retrack"
-version = "0.5.0"
+version = "0.6.0"
 description = "A business rules engine"
 authors = ["Gabriel Guarisa <gabrielguarisa@gmail.com>", "Nathalia Trotte <nathaliatrotte@gmail.com>"]
 license = "MIT"

--- a/retrack/engine/parser.py
+++ b/retrack/engine/parser.py
@@ -9,6 +9,7 @@ class Parser:
         self,
         graph_data: dict,
         component_registry: Registry = nodes.registry(),
+        dynamic_registry: Registry = nodes.dynamic_registry(),
         validator_registry: Registry = validators.registry(),
     ):
         self._execution_order = None
@@ -17,7 +18,7 @@ class Parser:
 
         self._check_input_data(graph_data)
 
-        self._set_components(graph_data, component_registry)
+        self._set_components(graph_data, component_registry, dynamic_registry)
         self._set_edges()
 
         self._validate_graph(graph_data, validator_registry)
@@ -52,7 +53,9 @@ class Parser:
     def components(self) -> typing.Dict[str, nodes.BaseNode]:
         return self.__components
 
-    def _set_components(self, graph_data: dict, component_registry: Registry):
+    def _set_components(
+        self, graph_data: dict, component_registry: Registry, dynamic_registry: Registry
+    ):
         for node_id, node_metadata in graph_data["nodes"].items():
             if node_id in self.__components:
                 raise ValueError(f"Duplicate node id: {node_id}")
@@ -61,6 +64,11 @@ class Parser:
             self._check_node_name(node_name, node_id)
 
             node_name = node_name.lower()
+
+            node_factory = dynamic_registry.get(node_name)
+
+            if node_factory is not None:
+                validation_model = node_factory(**node_metadata)
 
             validation_model = component_registry.get(node_name)
 

--- a/retrack/engine/parser.py
+++ b/retrack/engine/parser.py
@@ -69,8 +69,8 @@ class Parser:
 
             if node_factory is not None:
                 validation_model = node_factory(**node_metadata)
-
-            validation_model = component_registry.get(node_name)
+            else:
+                validation_model = component_registry.get(node_name)
 
             if validation_model is None:
                 raise ValueError(f"Unknown node name: {node_name}")

--- a/retrack/nodes/__init__.py
+++ b/retrack/nodes/__init__.py
@@ -3,6 +3,8 @@ from retrack.nodes.check import Check
 from retrack.nodes.constants import Bool, Constant, List
 from retrack.nodes.contains import Contains
 from retrack.nodes.datetime import CurrentYear
+from retrack.nodes.dynamic import BaseDynamicNode
+from retrack.nodes.dynamic import registry as dynamic_registry
 from retrack.nodes.endswith import EndsWith
 from retrack.nodes.endswithany import EndsWithAny
 from retrack.nodes.inputs import Input
@@ -46,4 +48,4 @@ register("EndsWithAny", EndsWithAny)
 register("Contains", Contains)
 register("CurrentYear", CurrentYear)
 
-__all__ = ["registry", "register", "BaseNode"]
+__all__ = ["registry", "register", "BaseNode", "dynamic_registry", "BaseDynamicNode"]

--- a/retrack/nodes/dynamic/__init__.py
+++ b/retrack/nodes/dynamic/__init__.py
@@ -1,0 +1,25 @@
+import typing
+
+from retrack.nodes.dynamic.base import BaseDynamicNode
+from retrack.nodes.dynamic.csv_table import csv_table_factory
+from retrack.utils.registry import Registry
+
+_registry = Registry()
+
+
+def registry() -> Registry:
+    return _registry
+
+
+def register(
+    name: str,
+    factory: typing.Callable[
+        [typing.List[str], typing.List[str]], typing.Type[BaseDynamicNode]
+    ],
+) -> None:
+    registry().register(name, factory)
+
+
+register("CSVTable", csv_table_factory)
+
+__all__ = ["registry", "register", "BaseDynamicNode"]

--- a/retrack/nodes/dynamic/__init__.py
+++ b/retrack/nodes/dynamic/__init__.py
@@ -20,6 +20,6 @@ def register(
     registry().register(name, factory)
 
 
-register("CSVTable", csv_table_factory)
+register("CSVTableV0", csv_table_factory)
 
 __all__ = ["registry", "register", "BaseDynamicNode"]

--- a/retrack/nodes/dynamic/base.py
+++ b/retrack/nodes/dynamic/base.py
@@ -1,0 +1,20 @@
+import typing
+
+import pydantic
+
+from retrack.nodes.base import BaseNode
+
+
+class BaseDynamicNode(BaseNode):
+    @classmethod
+    def with_fields(cls, class_name: str, **field_definitions):
+        return pydantic.create_model(class_name, __base__=cls, **field_definitions)
+
+    @staticmethod
+    def create_sub_field(
+        type_: typing.Any, optional: bool = False, default_value: typing.Any = None
+    ) -> typing.Tuple[typing.Type, typing.Any]:
+        if optional:
+            return (typing.Optional[type_], default_value)
+
+        return (type_, ...)

--- a/retrack/nodes/dynamic/base.py
+++ b/retrack/nodes/dynamic/base.py
@@ -5,10 +5,18 @@ import pydantic
 from retrack.nodes.base import BaseNode
 
 
+class BaseDynamicIOModel(pydantic.BaseModel):
+    @classmethod
+    def with_fields(cls, class_name: str, **field_definitions):
+        return pydantic.create_model(
+            class_name, __base__=BaseDynamicIOModel, **field_definitions
+        )
+
+
 class BaseDynamicNode(BaseNode):
     @classmethod
     def with_fields(cls, class_name: str, **field_definitions):
-        return pydantic.create_model(class_name, __base__=cls, **field_definitions)
+        return pydantic.create_model(class_name, __base__=BaseNode, **field_definitions)
 
     @staticmethod
     def create_sub_field(

--- a/retrack/nodes/dynamic/csv_table.py
+++ b/retrack/nodes/dynamic/csv_table.py
@@ -1,0 +1,75 @@
+import typing
+
+import pandas as pd
+import pydantic
+
+from retrack.nodes.base import InputConnectionModel, OutputConnectionModel
+from retrack.nodes.dynamic.base import BaseDynamicNode
+
+
+class CSVTableMetadataModel(pydantic.BaseModel):
+    value: typing.Union[typing.List[str], typing.List[typing.List[str]]]
+    target: str
+    headers: typing.List[str]
+    separator: typing.Optional[str] = ","
+    default: typing.Optional[str] = None
+
+    @pydantic.root_validator(pre=True)
+    def validate_value(cls, values):
+        value, separator = values.get("value", None), values.get("separator", ",")
+        if value is None:
+            raise ValueError("Value is required")
+
+        for i in range(len(value)):
+            value[i] = value[i].split(separator)
+
+        values["value"] = value
+        return values
+
+
+class CSVTableOutputsModel(pydantic.BaseModel):
+    output_value: OutputConnectionModel
+
+
+def csv_table_factory(
+    inputs: typing.Dict[str, typing.Any], **kwargs
+) -> typing.Type[BaseDynamicNode]:
+    input_fields = {}
+
+    for name in inputs.keys():
+        input_fields[name] = BaseDynamicNode.create_sub_field(InputConnectionModel)
+
+    inputs_model = BaseDynamicNode.with_fields("CSVTableInputsModel", **input_fields)
+
+    models = {
+        "inputs": BaseDynamicNode.create_sub_field(inputs_model),
+        "outputs": BaseDynamicNode.create_sub_field(CSVTableOutputsModel),
+        "data": BaseDynamicNode.create_sub_field(CSVTableMetadataModel),
+    }
+
+    BaseCSVTableModel = BaseDynamicNode.with_fields("CSVTable", **models)
+
+    class CSVTableModel(BaseCSVTableModel):
+        def run(self, **kwargs) -> typing.Dict[str, typing.Any]:
+            input_field_names = list(input_fields.keys())
+            csv_df = pd.DataFrame(self.data.value[1:], columns=self.data.value[0])
+
+            response_df = {}
+
+            for name in input_field_names:
+                if name not in kwargs.keys():
+                    raise ValueError(f"Missing input {name} in CSVTable node")
+
+                response_df[name] = kwargs[name]
+
+            response_df = pd.DataFrame(response_df)
+            response_df = response_df.merge(
+                csv_df, how="left", left_on=input_field_names
+            )
+
+            if self.data.default:
+                response_df[self.data.target] = response_df[self.data.target].fillna(
+                    self.data.default
+                )
+
+            return {"output_value": response_df[self.data.target]}

--- a/tests/test_nodes/test_csv_table.py
+++ b/tests/test_nodes/test_csv_table.py
@@ -1,0 +1,95 @@
+import pandas as pd
+import pydantic
+import pytest
+
+from retrack.nodes import dynamic_registry
+
+
+@pytest.fixture
+def csv_table_metadata():
+    return {
+        "id": 2,
+        "data": {
+            "separator": ",",
+            "value": [
+                "month,first_year,second_year,third_year",
+                "JAN,340,360,417",
+                "FEB,318,342,391",
+                "MAR,362,406,419",
+                "APR,348,396,461",
+                "MAY,363,420,472",
+                "JUN,435,472,535",
+                "JUL,491,548,622",
+                "AUG,505,559,606",
+                "SEP,404,463,508",
+                "OCT,359,407,461",
+                "NOV,310,362,390",
+                "DEC,337,405,432",
+            ],
+            "default": "200",
+            "headers": ["month", "first_year", "second_year", "third_year"],
+            "target": "output_value",
+            "headers_map": [
+                "input_value_0",
+                "input_value_1",
+                "input_value_2",
+                "output_value",
+            ],
+        },
+        "inputs": {
+            "input_value_0": {
+                "connections": [{"node": 4, "output": "output_value", "data": {}}]
+            },
+            "input_value_1": {
+                "connections": [{"node": 5, "output": "output_value", "data": {}}]
+            },
+            "input_value_2": {
+                "connections": [{"node": 6, "output": "output_value", "data": {}}]
+            },
+        },
+        "outputs": {
+            "output_value": {
+                "connections": [
+                    {"node": 7, "input": "input_void", "data": {}},
+                    {"node": 8, "input": "input_value_0", "data": {}},
+                ]
+            }
+        },
+        "name": "CSVTable",
+    }
+
+
+def test_get_csv_table_factory():
+    csv_table_factory = dynamic_registry().get("CSVTable")
+
+    assert callable(csv_table_factory)
+
+
+def test_create_model_from_factory(csv_table_metadata):
+    csv_table_factory = dynamic_registry().get("CSVTable")
+    CSVTable = csv_table_factory(**csv_table_metadata)
+
+    assert issubclass(CSVTable, pydantic.BaseModel)
+
+    model = CSVTable(**csv_table_metadata)
+
+    assert isinstance(model, CSVTable)
+    assert hasattr(model, "run")
+
+
+def test_csv_table_run(csv_table_metadata):
+    csv_table_factory = dynamic_registry().get("CSVTable")
+    CSVTable = csv_table_factory(**csv_table_metadata)
+
+    model = CSVTable(**csv_table_metadata)
+
+    payload = {
+        "input_value_0": pd.Series(["MAY", "JUN", "JUL", "AUG", "SEP"]),
+        "input_value_1": pd.Series(["363", "435", "491", "505", "-1"]),
+        "input_value_2": pd.Series(["420", "472", "548", "559", "463"]),
+    }
+
+    expected = pd.Series(["472", "535", "622", "606", model.data.default])
+
+    response = model.run(**payload)
+    assert response["output_value"].equals(expected)

--- a/tests/test_nodes/test_csv_table.py
+++ b/tests/test_nodes/test_csv_table.py
@@ -55,33 +55,33 @@ def csv_table_metadata():
                 ]
             }
         },
-        "name": "CSVTable",
+        "name": "CSVTableV0",
     }
 
 
 def test_get_csv_table_factory():
-    csv_table_factory = dynamic_registry().get("CSVTable")
+    csv_table_factory = dynamic_registry().get("CSVTableV0")
 
     assert callable(csv_table_factory)
 
 
 def test_create_model_from_factory(csv_table_metadata):
-    csv_table_factory = dynamic_registry().get("CSVTable")
-    CSVTable = csv_table_factory(**csv_table_metadata)
+    csv_table_factory = dynamic_registry().get("CSVTableV0")
+    CSVTableV0 = csv_table_factory(**csv_table_metadata)
 
-    assert issubclass(CSVTable, pydantic.BaseModel)
+    assert issubclass(CSVTableV0, pydantic.BaseModel)
 
-    model = CSVTable(**csv_table_metadata)
+    model = CSVTableV0(**csv_table_metadata)
 
-    assert isinstance(model, CSVTable)
+    assert isinstance(model, CSVTableV0)
     assert hasattr(model, "run")
 
 
 def test_csv_table_run(csv_table_metadata):
-    csv_table_factory = dynamic_registry().get("CSVTable")
-    CSVTable = csv_table_factory(**csv_table_metadata)
+    csv_table_factory = dynamic_registry().get("CSVTableV0")
+    CSVTableV0 = csv_table_factory(**csv_table_metadata)
 
-    model = CSVTable(**csv_table_metadata)
+    model = CSVTableV0(**csv_table_metadata)
 
     payload = {
         "input_value_0": pd.Series(["MAY", "JUN", "JUL", "AUG", "SEP"]),


### PR DESCRIPTION
It is now possible to create the node structure dynamically in the parser. 

To do so, just register the function responsible for building the node class in the dynamic node registry.  

In the library, the construction of such nodes is being done in `retrack/nodes/dynamic`.

The first node built this way is CSVTableV0, which dynamically generates input connections based on the structure passed to the parser.